### PR TITLE
Fix Kruise-Rollouts related labels merge issue

### DIFF
--- a/domain/util/util.go
+++ b/domain/util/util.go
@@ -7,19 +7,26 @@ import (
 	"strings"
 )
 
-//
 func MergeStringMap(base, toMerge map[string]string) map[string]string {
-	result := make(map[string]string)
-	for k, v := range base {
-		result[k] = v
-	}
-	for k, v := range toMerge {
-		result[k] = v
-	}
-	return result
+	return MergeLabelsWithFilter(base, toMerge, func(string) bool { return true })
 }
 
-//
+func MergeLabelsWithFilter(base, toMerge map[string]string, keyFilter func(string) bool) map[string]string {
+	result := make(map[string]string)
+	for k, v := range base {
+		if keyFilter(k) {
+			result[k] = v
+		}
+	}
+	for k, v := range toMerge {
+		if keyFilter(k) {
+			result[k] = v
+		}
+	}
+	return result
+
+}
+
 func ContainString(list []string, item string) bool {
 	for _, i := range list {
 		if i == item {
@@ -29,7 +36,6 @@ func ContainString(list []string, item string) bool {
 	return false
 }
 
-//
 func GetDeleteCheckSum(name string) string {
 	salt := os.Getenv("MD5_SALT")
 	if salt == "" {

--- a/domain/util/util_test.go
+++ b/domain/util/util_test.go
@@ -3,7 +3,7 @@ package util
 import (
 	"strings"
 	"testing"
-	
+
 	"gotest.tools/assert"
 )
 

--- a/domain/util/util_test.go
+++ b/domain/util/util_test.go
@@ -1,8 +1,10 @@
 package util
 
 import (
-	"gotest.tools/assert"
+	"strings"
 	"testing"
+	
+	"gotest.tools/assert"
 )
 
 func TestMergeStringMap(t *testing.T) {
@@ -11,4 +13,16 @@ func TestMergeStringMap(t *testing.T) {
 
 func TestMergeStringMap_1(t *testing.T) {
 	assert.Equal(t, MergeStringMap(map[string]string{"a": "1"}, nil)["a"], "1")
+}
+
+func TestMergeStringMap_Filter(t *testing.T) {
+	assert.Equal(t, len(MergeLabelsWithFilter(map[string]string{"app": "1", "rollouts.kruise.io/stable-revision": "55cc48bb98"}, map[string]string{"a": "2"}, func(key string) bool {
+		if strings.HasPrefix(key, "rollouts.kruise.io/") {
+			return false
+		}
+		if strings.HasPrefix(key, "k8slens-") {
+			return false
+		}
+		return true
+	})), 2)
 }


### PR DESCRIPTION
Basically, we should not merge labels with keys "rollouts.kruise.io/*"